### PR TITLE
Add PlatformIO and Arduino library manifests

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
+  "name": "MedianFilter",
+  "version": "1.0.0",
+  "description": "Heap-free, O(n) sliding-window median filter for embedded C/C++. Removes spike/impulse noise from analog signals with no dynamic memory allocation.",
+  "keywords": [
+    "median", "filter", "dsp", "signal processing", "noise reduction",
+    "sliding window", "embedded", "bare-metal", "real-time", "analog"
+  ],
+  "homepage": "https://github.com/accabog/MedianFilter",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/accabog/MedianFilter.git"
+  },
+  "authors": {
+    "name": "Alexandru Bogdan",
+    "url": "https://github.com/accabog",
+    "maintainer": true
+  },
+  "license": "MIT",
+  "frameworks": "*",
+  "platforms": "*",
+  "headers": ["MedianFilter.h", "MedianFilter.hpp"],
+  "export": {
+    "include": [
+      "MedianFilter.h",
+      "MedianFilter.c",
+      "MedianFilter.hpp",
+      "examples",
+      "LICENSE"
+    ]
+  },
+  "build": {
+    "libArchive": false
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=MedianFilter
+version=1.0.0
+author=Alexandru Bogdan
+maintainer=Alexandru Bogdan
+sentence=Heap-free sliding-window median filter for embedded C/C++.
+paragraph=Removes spike and impulse noise from analog signals with no dynamic memory allocation. Implements a bidirectional search from the median pointer for O(n/2) average insertion. Works with the C API (MedianFilter.h/.c) or the header-only C++ template (MedianFilter.hpp). No heap, no dependencies, suitable for bare-metal and RTOS targets.
+category=Signal Input/Output
+url=https://github.com/accabog/MedianFilter
+architectures=*
+includes=MedianFilter.h,MedianFilter.hpp
+license=MIT


### PR DESCRIPTION
## Summary
- Add `library.json` for PlatformIO Registry
- Add `library.properties` for Arduino Library Manager
- Both declare `architectures=*` / `platforms=*` for universal board compatibility